### PR TITLE
pseudobatch_tranform_pandas preserves the index of the original dataframe

### DIFF
--- a/pseudobatch/data_correction.py
+++ b/pseudobatch/data_correction.py
@@ -286,4 +286,6 @@ def pseudobatch_transform_pandas(
             concentration_in_feed=conc,
             sample_volume=df[sample_volume_colname].to_numpy(),
         )
+    # Copy the index from the original dataframe
+    out.index = df.index
     return out

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,7 +1,11 @@
 import pytest
 import pandas as pd
+import numpy as np
 
-from pseudobatch import pseudobatch_transform
+from pseudobatch import (
+    pseudobatch_transform,
+    pseudobatch_transform_pandas,
+)
 from pseudobatch.datasets import (
     load_standard_fedbatch,
     load_product_inhibited_fedbatch,
@@ -41,3 +45,19 @@ def test_load_cho_cell_like_fedbatch_unique_timestamps():
     df = load_cho_cell_like_fedbatch()
     assert df.empty is False
     assert df["timestamp"].duplicated().sum() == 0
+
+def test_pseudobatch_transform_pandas_preserves_index():
+    """Test that the index of the input dataframe is preserved in the output dataframe."""
+    df = load_standard_fedbatch()
+
+    # change index to something else
+    df.index = np.arange(1000, 1000 + len(df))
+    transformed_df = pseudobatch_transform_pandas(
+        df=df,
+        measured_concentration_colnames=["c_Glucose"],
+        reactor_volume_colname="v_Volume",
+        accumulated_feed_colname="v_Feed_accum",
+        concentration_in_feed=[df.s_f.iloc[0]],
+        sample_volume_colname="sample_volume",
+    )
+    assert df.index.equals(transformed_df.index)


### PR DESCRIPTION
The title says it all. This is just a small change, but preserving the original index is very helpful when the transformed data is put back into the original data.