### PR TITLE
12 pseudobatch transform pandas validate input

### DIFF
--- a/pseudobatch/data_correction.py
+++ b/pseudobatch/data_correction.py
@@ -255,8 +255,8 @@ def pseudobatch_transform_pandas(
         given in measured_concentration_colnames. If multiple feed streams are
         given, the concentration_in_feed should be a list of lists. E.g.
         [[conc_Glc_feed1, conc_Glc_feed2], [conc_Biomass_feed1,
-        conc_Biomass_feed2]]. Thus, the outer list iterates over the feed
-        streams and the inner list iterates over the species. The order has to
+        conc_Biomass_feed2]]. Thus, the outer list iterates over the species
+        and the inner list iterates over the feed streams. The order has to
         match the order of the species, and accumulated feeds given in
         measured_concentration_colnames and accumulated_feed_colname.
 
@@ -278,6 +278,43 @@ def pseudobatch_transform_pandas(
         species for each column.
 
     """
+
+    # convert input to list if only one column name is given
+    if isinstance(measured_concentration_colnames, str):
+        measured_concentration_colnames = [measured_concentration_colnames]
+    if isinstance(concentration_in_feed, float) | isinstance(concentration_in_feed, int):
+        concentration_in_feed = [concentration_in_feed]
+
+    # validate input
+    if len(measured_concentration_colnames) != len(concentration_in_feed):
+        raise ValueError(
+            "The number of species given in measured_concentration_colnames and "
+            "concentration_in_feed does not match. Please check the input."
+            "Remeber also add concentration of the species that are present in the "
+            "feed, i.e. 0."
+        )
+
+    if isinstance(accumulated_feed_colname, Iterable) and not isinstance(accumulated_feed_colname, str):
+        logging.info(type(accumulated_feed_colname))
+        logging.info(accumulated_feed_colname)
+        # if multiple feed streams are given, we validate that each list in the
+        # the concentration_in_feed has the same length as the number of feeds
+        for conc_lst in concentration_in_feed: 
+            if not(isinstance(conc_lst, Iterable)):
+                raise ValueError(
+                    "If multiple feeds are given, the "
+                    "concentration_in_feed argument should be a list of Iterables. "
+                    f"{conc_lst} is not an Iterable. Please check the input."
+                )
+
+            if len(conc_lst) != len(accumulated_feed_colname):
+                raise ValueError(
+                    f"{len(accumulated_feed_colname)} feeds are given, but "
+                    "one of the lists in concentration_in_feed has length "
+                    f"{len(conc_lst)}. Please check the input."
+                )
+
+
     out = pd.DataFrame()
     for species, conc in zip(
         measured_concentration_colnames, concentration_in_feed

--- a/pseudobatch/data_correction.py
+++ b/pseudobatch/data_correction.py
@@ -295,8 +295,6 @@ def pseudobatch_transform_pandas(
         )
 
     if isinstance(accumulated_feed_colname, Iterable) and not isinstance(accumulated_feed_colname, str):
-        logging.info(type(accumulated_feed_colname))
-        logging.info(accumulated_feed_colname)
         # if multiple feed streams are given, we validate that each list in the
         # the concentration_in_feed has the same length as the number of feeds
         for conc_lst in concentration_in_feed: 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -89,4 +89,24 @@ def test_pseudobatch_transform_pandas_validation_missing_concentration_in_feed()
             concentration_in_feed=df.s_f.iloc[0],
             sample_volume_colname="sample_volume",
         )
+
+
+def test_pseudobatch_transform_pandas_validation_multiple_feeds():
+    """Tests that validation fails if the concentration_in_feed is incorectly formatted,
+    when multiple feeds are used.
+    
+    In this test the inner lists in concentration_in_feed iterates over the measured_concentration_colnames
+    this is WRONG. The inner lists should iterate over the feeds."""
+
+    df = load_cho_cell_like_fedbatch()
+
+    with pytest.raises(ValueError) as _:
+        pseudobatch_transform_pandas(
+            df=df,
+            measured_concentration_colnames=["c_Glucose", 'c_Biomass', "c_Glutamine"],
+            reactor_volume_colname="v_Volume",
+            accumulated_feed_colname=["v_Feed_accum", "v_Feed_accum_2"],
+            concentration_in_feed=[[df.c_Glucose_feed1.iloc[0] , 0, df.c_Glutamate_feed1], [0, 0, df.c_Glutamate_feed2]],
+            sample_volume_colname="sample_volume",
+        )
     

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -65,11 +65,28 @@ def test_pseudobatch_transform_pandas_preserves_index():
     df.index = np.arange(1000, 1000 + len(df))
     transformed_df = pseudobatch_transform_pandas(
         df=df,
-        measured_concentration_colnames=["c_Glucose"],
+        measured_concentration_colnames="c_Glucose",
         reactor_volume_colname="v_Volume",
         accumulated_feed_colname="v_Feed_accum",
-        concentration_in_feed=[df.s_f.iloc[0]],
+        concentration_in_feed=df.s_f.iloc[0],
         sample_volume_colname="sample_volume",
     )
     assert df.index.equals(transformed_df.index)
+
+
+def test_pseudobatch_transform_pandas_validation_missing_concentration_in_feed():
+    """Test that the validation fails when the number of measured_concentration_colnames is
+    not equal to the number of length of concentration in feed."""
+    df = load_standard_fedbatch()
+
+    # missing concentration in feed data
+    with pytest.raises(ValueError) as _:
+        pseudobatch_transform_pandas(
+            df=df,
+            measured_concentration_colnames=["c_Glucose", 'c_Biomass'],
+            reactor_volume_colname="v_Volume",
+            accumulated_feed_colname="v_Feed_accum",
+            concentration_in_feed=df.s_f.iloc[0],
+            sample_volume_colname="sample_volume",
+        )
     


### PR DESCRIPTION
This PR implements a few validations on the input of pseudobatch_transform_pandas. Validations steps attempt to catch wrong formatted inputs, e.g. not to specify a concentration_in_feed for all transformed species. It does also catch some errors when using multiple feed streams.